### PR TITLE
Evitar preguntar por las dependencias

### DIFF
--- a/wgc
+++ b/wgc
@@ -92,8 +92,8 @@ if [ "$1" = "-iu" ] ; then
 if [ $(id -u) -eq 0 ] 
 then
     apt-get update && apt-get upgrade -y
-    apt install wireguard
-    apt install qrencode
+    apt install wireguard -y
+    apt install qrencode -y
     sed -i "s/#*\s*net.ipv4.ip_forward\s*=\s*[01]/net.ipv4.ip_forward = 1/g" /etc/sysctl.conf
     sudo sysctl -w net.ipv4.ip_forward=1
     reboot
@@ -123,7 +123,7 @@ then
         printf "Package: *\nPin: release a=unstable\nPin-Priority: 150\n" | tee -a /etc/apt/preferences.d/limit-unstable
     fi
     apt-get update && apt-get install -y wireguard
-    apt install qrencode
+    apt install qrencode -y
     sed -i "s/#*\s*net.ipv4.ip_forward\s*=\s*[01]/net.ipv4.ip_forward = 1/g" /etc/sysctl.conf
     sudo sysctl -w net.ipv4.ip_forward=1
     reboot
@@ -142,7 +142,7 @@ then
     echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.list.d/unstable.list
     printf 'Package: *\nPin: release a=unstable\nPin-Priority: 90\n' > /etc/apt/preferences.d/limit-unstable
     apt-get update && apt-get install -y wireguard
-    apt install qrencode
+    apt install qrencode -y
     sed -i "s/#*\s*net.ipv4.ip_forward\s*=\s*[01]/net.ipv4.ip_forward = 1/g" /etc/sysctl.conf
     sudo sysctl -w net.ipv4.ip_forward=1
     reboot


### PR DESCRIPTION
Evita que pregunte por las dependencias al instalar wireguard o qrencode en ubuntu y raspbian